### PR TITLE
C3f message parsing fix

### DIFF
--- a/RFExplorer/RFEConfiguration.py
+++ b/RFExplorer/RFEConfiguration.py
@@ -163,9 +163,9 @@ class RFEConfiguration:
                     self.m_eMode = RFE_Common.eMode.MODE_GEN_SWEEP_AMP
                 elif (sLine[4] == 'F'):
                     #Sweep Frequency mode
-                    self.fStartMHZ = int(sLine[6:7]) / 1000.0 #Note it comes in KHZ
+                    self.fStartMHZ = int(sLine[6:13]) / 1000.0 #Note it comes in KHZ
                     self.nFreqSpectrumSteps = int(sLine[14:18])
-                    self.fStepMHZ = int(sLine[19:7]) / 1000.0  #Note it comes in KHZ
+                    self.fStepMHZ = int(sLine[19:26]) / 1000.0  #Note it comes in KHZ
                     self.bRFEGenHighPowerSwitch = (sLine[27] == '1')
                     self.nRFEGenPowerLevel = int(ord(sLine[29]) - 0x30)
                     self.bRFEGenPowerON = (sLine[31] == '1')

--- a/RFExplorer/RFEConfiguration.py
+++ b/RFExplorer/RFEConfiguration.py
@@ -163,6 +163,9 @@ class RFEConfiguration:
                     self.m_eMode = RFE_Common.eMode.MODE_GEN_SWEEP_AMP
                 elif (sLine[4] == 'F'):
                     #Sweep Frequency mode
+                    # r'#C3-F:0221000,0020,0000100,0,0,1,00150'
+                    #       0 6      11   11      22 2 3 3    3
+                    #       4 6      34   89      67 9 1 3    8
                     self.fStartMHZ = int(sLine[6:13]) / 1000.0 #Note it comes in KHZ
                     self.nFreqSpectrumSteps = int(sLine[14:18])
                     self.fStepMHZ = int(sLine[19:26]) / 1000.0  #Note it comes in KHZ
@@ -173,6 +176,9 @@ class RFEConfiguration:
                     self.m_eMode = RFE_Common.eMode.MODE_GEN_SWEEP_FREQ
                 elif (sLine[4] == 'G'):
                     #Normal CW mode
+                    # r'#C3-G:0432144,0432144,0020,0000100,0,0,0'
+                    #       0         1      22   22      33 3 3
+                    #       4         4      12   67      45 7 9
                     self.fRFEGenCWFreqMHZ = int(sLine[14:21]) / 1000.0  #Note it comes in KHZ
                     self.nFreqSpectrumSteps = int(sLine[22:26])
                     self.fStepMHZ = int(sLine[27:34]) / 1000.0  #Note it comes in KHZ

--- a/RFExplorer/RFEConfiguration.py
+++ b/RFExplorer/RFEConfiguration.py
@@ -164,7 +164,7 @@ class RFEConfiguration:
                 elif (sLine[4] == 'F'):
                     #Sweep Frequency mode
                     # r'#C3-F:0221000,0020,0000100,0,0,1,00150'
-                    #       0 6      11   11      22 2 3 3    3
+                    #       0 0      11   11      22 2 3 3    3
                     #       4 6      34   89      67 9 1 3    8
                     self.fStartMHZ = int(sLine[6:13]) / 1000.0 #Note it comes in KHZ
                     self.nFreqSpectrumSteps = int(sLine[14:18])

--- a/RFExplorer/RFEConfiguration.py
+++ b/RFExplorer/RFEConfiguration.py
@@ -164,8 +164,7 @@ class RFEConfiguration:
                 elif (sLine[4] == 'F'):
                     #Sweep Frequency mode
                     # r'#C3-F:0221000,0020,0000100,0,0,1,00150'
-                    #       0 0      11   11      22 2 3 3    3
-                    #       4 6      34   89      67 9 1 3    8
+                    # Positions:6,14,19,27,29,31,33
                     self.fStartMHZ = int(sLine[6:13]) / 1000.0 #Note it comes in KHZ
                     self.nFreqSpectrumSteps = int(sLine[14:18])
                     self.fStepMHZ = int(sLine[19:26]) / 1000.0  #Note it comes in KHZ
@@ -177,8 +176,7 @@ class RFEConfiguration:
                 elif (sLine[4] == 'G'):
                     #Normal CW mode
                     # r'#C3-G:0432144,0432144,0020,0000100,0,0,0'
-                    #       0         1      22   22      33 3 3
-                    #       4         4      12   67      45 7 9
+                    # Positions:14,22,27,35,37,39
                     self.fRFEGenCWFreqMHZ = int(sLine[14:21]) / 1000.0  #Note it comes in KHZ
                     self.nFreqSpectrumSteps = int(sLine[22:26])
                     self.fStepMHZ = int(sLine[27:34]) / 1000.0  #Note it comes in KHZ


### PR DESCRIPTION
The #c3-f message parsing was using start:len to index strings for the fields fStartMHZ and fStepMHZ

The correct way in Python is to index as start:stop, and this is corrected in this branch with commit 41b4389 . I have tested this on my signal generator and it works.

In addition, commit 0d237ca adds sample strings received from my signal generator for #C3-F and #C3-G messages and labels relevant columns.  These are in comment lines and shouldn't affect the code. I feel this helps to document the string parsing, but if you feel this clutters the code, I'm OK with you omitting this commit, but you should still pick up the fix from 41b4389. 