### PR TITLE
initialize m_arrValidCP2102Ports in GetConnectedPorts() 

### DIFF
--- a/RFExplorer/RFExplorer.py
+++ b/RFExplorer/RFExplorer.py
@@ -1083,6 +1083,7 @@ class RFECommunicator(object):
 		"""
         bOk = True
         sValidPorts = ""
+        self.m_arrValidCP2102Ports = []
 
         try:
             self.m_arrConnectedPorts = list(serial.tools.list_ports.comports())
@@ -1530,4 +1531,4 @@ class RFECommunicator(object):
 
         except RuntimeError:
             print("Error importing RPi.GPIO!  This is probably because you need superuser privileges.  You can achieve this by using 'sudo' to run your script")
-        
+ 


### PR DESCRIPTION
self.m_arrValidCP2102Ports is only initialized in __init__
GetConnectedPorts() appends valid ports to this array, but does not initialize it, so repeated calls to GetConnectedPorts() causes this array to grow each call with repeated copies of the same device.  

This commit adds initialization of m_arrValidCP2102Ports  to GetConnectedPorts() and keep it mangeable.  

This probably wasn't noticed since the example scripts only called GetConnectedPorts() once per execution. I am working on a Python/tkinter GUI with a button to re-scan for connected serial ports. It is easier to notice on repeated button clicks.

There also appeared to be a missing newline at the end of the file.  My editor put that in automatically, I hope that isn't an issue.
