### PR TITLE
parse RFE6GEN calibration '#$q' messages

### DIFF
--- a/RFExplorer/RFE6GEN_CalibrationData.py
+++ b/RFExplorer/RFE6GEN_CalibrationData.py
@@ -418,7 +418,7 @@ class RFE6GEN_CalibrationData:
             return sReport
             
         # skip leading '$q'
-        nSize -=2 
+        nSize -=3
 
         #Values using 10*delta from the value delivered when compared with 30dBm.
         #For instance if value delivered for a frequency is -28.5dBm, that is a +1.5dB difference
@@ -426,7 +426,7 @@ class RFE6GEN_CalibrationData:
         #therefore a -32 value.
 
         self.m_arrSignalGeneratorEmbeddedCalibrationActual30DBM =\
-                    [ (-30.0 + float( c_int8( ord(c) ).value ) / 10.0) for c in sLine[2:] ]
+                    [ (-30.0 + float( c_int8( ord(c) ).value ) / 10.0) for c in sLine[3:] ]
             
         for nInd in range(nSize):
             if nInd and ((nInd % 16) == 0):

--- a/RFExplorer/RFE6GEN_CalibrationData.py
+++ b/RFExplorer/RFE6GEN_CalibrationData.py
@@ -22,6 +22,8 @@
 #Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #=============================================================================
 
+from ctypes import c_int8
+
 class RFE6GEN_CalibrationData:
     """note this is shared with RFEGenTest
     """
@@ -412,19 +414,26 @@ class RFE6GEN_CalibrationData:
         if (not sLine):
             return sReport
 
+        if nSize < 164:
+            return sReport
+            
+        # skip leading '$q'
+        nSize -=2 
+
         #Values using 10*delta from the value delivered when compared with 30dBm.
         #For instance if value delivered for a frequency is -28.5dBm, that is a +1.5dB difference
         #therefore a 1.5*10=15 value. If the value delivered is -33.2 that is a -3.2dB difference
         #therefore a -32 value.
 
+        self.m_arrSignalGeneratorEmbeddedCalibrationActual30DBM =\
+                    [ (-30.0 + float( c_int8( ord(c) ).value ) / 10.0) for c in sLine[2:] ]
+            
         for nInd in range(nSize):
-            self.m_arrSignalGeneratorEmbeddedCalibrationActual30DBM[nInd] = -30.0 + int(sLine[nInd + 3]) / 10.0
-            if (not sLine):
-                if ((nInd % 16) == 0):
-                    sReport += '\n'
-                sReport += '{:04.1f}'.format(self.m_arrSignalGeneratorEmbeddedCalibrationActual30DBM[nInd]) 
-                if (nInd < nSize - 1):
-                    sReport += ","
+            if nInd and ((nInd % 16) == 0):
+                sReport += '\n'
+            sReport += '{:04.1f}'.format(self.m_arrSignalGeneratorEmbeddedCalibrationActual30DBM[nInd]) 
+            if (nInd < nSize - 1):
+                sReport += ","
 
         return sReport
 

--- a/RFExplorer/RFExplorer.py
+++ b/RFExplorer/RFExplorer.py
@@ -984,6 +984,14 @@ class RFECommunicator(object):
                             self.m_eExpansionBoardModel = RFE_Common.eModel(int(sLine[10:13]))
                             self.m_sRFExplorerFirmware = sLine[14:19]
 
+                        # RFE6GEN calibration data '$q' message
+                        elif ( (len(sLine) >= 164) and (sLine[:2] == '$q') ):
+                            sReport = self.m_RFGenCal.InitializeCal( len(sLine), sLine, "" )
+                            if ( sReport == "" ):
+                                print("Invalid calibration data!")
+                            else:
+                                print("RFE6GEN calibration data:\n" + sReport)
+
                         elif ((len(sLine) > 18) and (sLine[:18] == RFE_Common.CONST_RESETSTRING)):
                             #RF Explorer device was reset for some reason, reconfigure client based on new configuration
                             self.m_bIsResetEvent = True

--- a/RFExplorer/ReceiveSerialThread.py
+++ b/RFExplorer/ReceiveSerialThread.py
@@ -132,13 +132,16 @@ class ReceiveSerialThread(threading.Thread):
                                 self.m_hQueueLock.release() 
 
                         elif (nLen > 2 and ((strReceived[1] == 'q') or (strReceived[1] == 'Q'))):
-                            # Not sure what $q responses are, but I see them on the siggen
-                            # and need to drop them to unplug the receive queue
+                            # $q responses are RFE6GEN calibration data 
                             nEndPos = strReceived.find("\r\n")
                             if (nEndPos >= 0):
+                                sNewLine = strReceived[:nEndPos]
                                 sLeftOver = strReceived[nEndPos + 2:]
                                 strReceived = sLeftOver
-                                #print("sLeftOver: " + strReceived)
+                                if nEndPos >= 164:
+                                    self.m_hQueueLock.acquire() 
+                                    self.m_objQueue.put( sNewLine )
+                                    self.m_hQueueLock.release() 
 
                         elif (nLen > 1 and (strReceived[1] == 'D')):
                             #This is dump screen data

--- a/RFExplorer/ReceiveSerialThread.py
+++ b/RFExplorer/ReceiveSerialThread.py
@@ -132,7 +132,13 @@ class ReceiveSerialThread(threading.Thread):
                                 self.m_hQueueLock.release() 
 
                         elif (nLen > 2 and ((strReceived[1] == 'q') or (strReceived[1] == 'Q'))):
-                            pass
+                            # Not sure what $q responses are, but I see them on the siggen
+                            # and need to drop them to unplug the receive queue
+                            nEndPos = strReceived.find("\r\n")
+                            if (nEndPos >= 0):
+                                sLeftOver = strReceived[nEndPos + 2:]
+                                strReceived = sLeftOver
+                                #print("sLeftOver: " + strReceived)
 
                         elif (nLen > 1 and (strReceived[1] == 'D')):
                             #This is dump screen data


### PR DESCRIPTION
My signal generator was produces '#$q' messages that are not parsed out in ReceiveSerialThread.py

This causes strReceived to fill up and prevent further messages from being parsed. Stripping them out by advancing  strReceived to the next line clears this up, and seems to work on my siggen.

I am not sure what is in the '#$q' messages, I hope this doesn't cause issues on other devices. If it does, code will need to be added to properly parse these messages.