### PR TITLE
fix minor typo in RFEConfiguration.py

### DIFF
--- a/RFExplorer/RFEConfiguration.py
+++ b/RFExplorer/RFEConfiguration.py
@@ -91,7 +91,7 @@ class RFEConfiguration:
 
     @property
     def LineString(self):
-        """Complete sting line with all configuration data
+        """Complete string line with all configuration data
 		"""
         return self.m_sLineString
     


### PR DESCRIPTION
minor typo in the comment header for LineString().  This does show up in the class documentation strings.