### PR TITLE
Change string encoding to utf-8

### DIFF
--- a/RFExplorer/RFExplorer.py
+++ b/RFExplorer/RFExplorer.py
@@ -1509,7 +1509,7 @@ class RFECommunicator(object):
             sCommand -- Unformatted command from http://www.rf-explorer.com/API
 		"""
         sCompleteCommand = "#" + chr(len(sCommand) + 2) + sCommand
-        self.m_objSerialPort.write(sCompleteCommand.encode('ascii'))
+        self.m_objSerialPort.write(sCompleteCommand.encode('utf-8'))
         if self.m_nVerboseLevel>5:
             print("RFE Command: #(" + str(len(sCompleteCommand)) + ")" + sCommand + " [" + " ".join("{:02X}".format(ord(c)) for c in sCompleteCommand) + "]")
     


### PR DESCRIPTION
to allow wider range of characters.
https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.write

Encoding in ascii would fail SendCommand_SweepDataPoints(4096) for example.