### PR TITLE
Encode latin1

### DIFF
--- a/RFExplorer/RFExplorer.py
+++ b/RFExplorer/RFExplorer.py
@@ -1509,7 +1509,7 @@ class RFECommunicator(object):
             sCommand -- Unformatted command from http://www.rf-explorer.com/API
 		"""
         sCompleteCommand = "#" + chr(len(sCommand) + 2) + sCommand
-        self.m_objSerialPort.write(sCompleteCommand.encode('utf-8'))
+        self.m_objSerialPort.write(sCompleteCommand.encode('latin1'))
         if self.m_nVerboseLevel>5:
             print("RFE Command: #(" + str(len(sCompleteCommand)) + ")" + sCommand + " [" + " ".join("{:02X}".format(ord(c)) for c in sCompleteCommand) + "]")
     


### PR DESCRIPTION
changing command encoding to utf-8 in 2d9f32923dd856481f059905fda2990674c3a453 didn't break the existing code but didn't solve the issue, neither.

Using latin1 encoding may not be the best solution but at least it makes SendCommand_SweepDataPoints(4096) to work properly.
