### PR TITLE
fix: InputStageAvailable is a property

### DIFF
--- a/RFExplorer/RFExplorer.py
+++ b/RFExplorer/RFExplorer.py
@@ -790,7 +790,7 @@ class RFECommunicator(object):
         return self.m_eInputStage
     @InputStage.setter
     def InputStage(self, value):
-        if (self.IsInputStageAvailable()):
+        if (self.IsInputStageAvailable):
             nNewInputStage = value;
             if (self.m_eActiveModel == RFE_Common.eModel.MODEL_2400_PLUS):
                 if (nNewInputStage == RFE_Common.eInputStage.LNA_12dB):


### PR DESCRIPTION
`IsInputStageAvailable` is a property that returns a bool, however it is called as a function in the InputStage setter.

setting the `InputStage` property raises:
```
TypeError: 'bool' object is not callable
```

this fix accesses it as a property instead of as a function